### PR TITLE
In `utils.highest_scan_id`, get `scan_id` from `brain` index instead metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 
 - Commented unneeded code.
   [sgeulette]
+- In `utils.highest_scan_id`, get `scan_id` from `brain` index instead metadata
+  in case there is a desynchronization between index and metadata and we are
+  sure we are re-using the same value as the one used to get
+  the highest index value.
+  [gbastien]
 
 0.9 (2024-02-12)
 ----------------

--- a/src/imio/zamqp/core/utils.py
+++ b/src/imio/zamqp/core/utils.py
@@ -21,7 +21,9 @@ def highest_scan_id(file_portal_types=['dmsmainfile']):
         sort_limit=1)
     # highest_id = None
     if brains:
-        return brains[0].scan_id
+        # we use the index value so we are sure it is the same value
+        # used in the previous catalog.unrestrictedSearchResults query
+        return catalog.getIndexDataForRID(brains[0].getRID())['scan_id']
         # for brain in brains:  # no idea why this code was added in place of brains[0]
         #     if brain.scan_id != 'None':
         #         highest_id = brain.scan_id

--- a/test-4.3.cfg
+++ b/test-4.3.cfg
@@ -22,6 +22,7 @@ traitlets = 4.3.3
 # Upper version need zope.configuration 3.8
 z3c.unconfigure = 1.0.1
 pdbpp = 0.10.3
+six = 1.16.0
 
 # Required by:
 # plone.versioncheck

--- a/test-4.3.cfg
+++ b/test-4.3.cfg
@@ -21,6 +21,7 @@ future = 0.18.2
 traitlets = 4.3.3
 # Upper version need zope.configuration 3.8
 z3c.unconfigure = 1.0.1
+pdbpp = 0.10.3
 
 # Required by:
 # plone.versioncheck


### PR DESCRIPTION
… in case there is a desynchronization between index and metadata and we are sure we are re-using the same value as the one used to get the highest index value.

See #MOD-965